### PR TITLE
Fix missing $data field exception

### DIFF
--- a/src/Borica.php
+++ b/src/Borica.php
@@ -136,8 +136,8 @@ class Borica {
         $message = '';
 
         foreach ($macFields[$data['TRTYPE']] as $field) {
-            $value = $data[$field];
-
+            $value = isset($data[$field]) ? $data[$field] : null;
+            
             // When field is missing, use symbol `-`
             if (mb_strlen($value) == 0) {
                 $message .= '-';
@@ -164,8 +164,8 @@ class Borica {
         $message = '';
 
         foreach ($macFields[$data['TRTYPE']] as $field) {
-            $value = $data[$field];
-
+            $value = isset($data[$field]) ? $data[$field] : null;
+            
             // When field in response is missing, use symbol `-`
             if ($isResponse && mb_strlen($value) == 0) {
                 $message .= '-';


### PR DESCRIPTION
Fixing [BUG] RFU issue #15


Notes:
I used `isset` instead of `??` operator as its not supported in PHP 7
```
$value = isset($data[$field]) ? $data[$field] : null;
```